### PR TITLE
POD-2677: Make Terra API call return types more consistent

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,2 +1,2 @@
-8.7.1
-- Update readme to include instructions on how to use repo within a Terra environment
+9.0.0
+- Update all Terra utilities to return entire response objects when possible for consistency

--- a/ops_utils/request_util.py
+++ b/ops_utils/request_util.py
@@ -160,7 +160,7 @@ class RunRequest:
             headers["accept"] = accept
         return headers
 
-    def upload_file(self, uri: str, data: dict) -> str:
+    def upload_file(self, uri: str, data: dict) -> requests.Response:
         """
         Run a POST request with files parameter.
 
@@ -169,11 +169,10 @@ class RunRequest:
         - data (dict): The files data to upload.
 
         **Returns:**
-        - str: The response text from the request.
+        - requests.Response: The response from the request.
         """
         headers = self.create_headers(accept=None)
         response = requests.post(uri, headers=headers, files=data)
         if 300 <= response.status_code or response.status_code < 200:
-            print(response.text)
             response.raise_for_status()  # Raise an exception for non-200 status codes
-        return response.text
+        return response

--- a/ops_utils/tdr_utils/tdr_ingest_utils.py
+++ b/ops_utils/tdr_utils/tdr_ingest_utils.py
@@ -36,7 +36,7 @@ class BatchIngest:
             skip_reformat: bool = False
     ):
         """
-        Initialize the BatchIngest class. 
+        Initialize the BatchIngest class.
 
         **Args:**
         - ingest_metadata (list[dict]): The metadata to be ingested.
@@ -93,10 +93,10 @@ class BatchIngest:
     @staticmethod
     def _reformat_for_type_consistency(ingest_metadata: list[dict]) -> list[dict]:
         """
-        Reformats ingest metadata and finds headers where values are a mix of lists and non-lists. 
-        
-        If there is mix of these types of values, it converts the non-array to a one-item list. The updated metadata is then returned to
-        be used for everything downstream
+        Reformats ingest metadata and finds headers where values are a mix of lists and non-lists.
+
+        If there is mix of these types of values, it converts the non-array to a one-item list. The updated metadata
+        is then returned to be used for everything downstream
         """
         unique_headers = sorted({key for item in ingest_metadata for key in item.keys()})
 
@@ -253,7 +253,7 @@ class ReformatMetricsForIngest:
     ):
         """
         Initialize the ReformatMetricsForIngest class.
-        
+
         This class is used to reformat metrics for ingest.
         Assumes input JSON will be in the following format for GCP:
         ```
@@ -315,7 +315,7 @@ class ReformatMetricsForIngest:
     def _check_and_format_file_path(self, column_value: str) -> tuple[Any, bool]:
         """
         Check if column value is a gs:// path and reformat to dict with ingest information.
-        
+
         If file_to_uuid_dict is
         provided then it will add existing UUID. If file_to_uuid_dict provided and file not found then will warn and
         return None.
@@ -466,7 +466,7 @@ class ConvertTerraTableInfoForIngest:
     ):
         """
         Initialize the ConvertTerraTableInfoForIngest class.
-        
+
         Input will look like this:
         ```
             [{
@@ -639,7 +639,7 @@ class FilterAndBatchIngest:
 
 class GetPermissionsForWorkspaceIngest:
     """Obtain permissions necessary for workspace ingest."""
-    
+
     def __init__(self, terra_workspace: TerraWorkspace, dataset_info: dict, added_to_auth_domain: bool = False):
         """
         Initialize the GetPermissionsForWorkspaceIngest class.
@@ -670,7 +670,7 @@ class GetPermissionsForWorkspaceIngest:
         self.terra_workspace.update_user_acl(email=tdr_sa_account, access_level="READER")
 
         # Check if workspace has auth domain
-        workspace_info = self.terra_workspace.get_workspace_info()
+        workspace_info = self.terra_workspace.get_workspace_info().json()
         auth_domain_list = workspace_info["workspace"]["authorizationDomain"]
         # Attempt to add tdr_sa_account to auth domain
         if auth_domain_list:

--- a/ops_utils/tests/test_terra_utils.py
+++ b/ops_utils/tests/test_terra_utils.py
@@ -21,7 +21,7 @@ class TestTerraWorkspaceUtils:
     @responses.activate
     def test_get_workspace(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/get_workspace.yaml")
-        workspace_info = self.workspace.get_workspace_info()
+        workspace_info = self.workspace.get_workspace_info().json()
         assert workspace_info
 
     @responses.activate
@@ -33,13 +33,13 @@ class TestTerraWorkspaceUtils:
     @responses.activate
     def test_get_workspace_entity_info(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/workspace_entity_info.yaml")
-        entify_info = self.workspace.get_workspace_entity_info()
+        entify_info = self.workspace.get_workspace_entity_info().json()
         assert entify_info['file_metadata']['idName'] == "file_metadata_id"
 
     @responses.activate
     def test_get_workspace_acl(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/workspace_acl_info.yaml")
-        workspace_acl = self.workspace.get_workspace_acl()
+        workspace_acl = self.workspace.get_workspace_acl().json()
         assert workspace_acl
 
     @responses.activate
@@ -51,33 +51,33 @@ class TestTerraWorkspaceUtils:
     @responses.activate
     def test_get_workspace_workflows(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/get_workspace_workflows.yaml")
-        workflows = self.workspace.get_workspace_workflows()
+        workflows = self.workspace.get_workspace_workflows().json()
         assert workflows
 
     @responses.activate
     def test_check_workspace_public(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/check_workspace_public.yaml")
-        workspace_public = self.workspace.check_workspace_public()
+        workspace_public = self.workspace.check_workspace_public().json()
         assert not workspace_public
 
     @responses.activate
     def test_create_workspace(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/create_workspace.yaml")
-        new_workspace_metadata = self.workspace.create_workspace()
+        new_workspace_metadata = self.workspace.create_workspace().json()
         assert new_workspace_metadata
 
     @responses.activate
     def test_update_workspace_attributes(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/update_workspace_attributes.yaml")
         attributes = [{"op": "AddUpdateAttribute", "attributeName": "dataset_id", "addUpdateAttribute": 'ex-dataset-guid'}]
-        workspace_update = self.workspace.update_workspace_attributes(attributes=attributes)
-        assert workspace_update is None
+        workspace_update = self.workspace.update_workspace_attributes(attributes=attributes).json()
+        assert workspace_update
 
     @responses.activate
     def test_update_user_acl(self):
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/update_acl.yaml")
         update_acl = self.workspace.update_user_acl(
-            email='test-account@integration-project.iam.gserviceaccount.com', access_level='READER')
+            email='test-account@integration-project.iam.gserviceaccount.com', access_level='READER').json()
         assert update_acl
 
     @responses.activate
@@ -85,7 +85,7 @@ class TestTerraWorkspaceUtils:
         responses._add_from_file(file_path="ops_utils/tests/data/terra_util/update_multiple_acl.yaml")
         acl_list = [{"email": "test@broadinstitute.org", "accessLevel": "READER", "canShare": False, "canCompute": False, },
                     {"email": "test-account@integration-project.iam.gserviceaccount.com", "accessLevel": "READER", "canShare": False, "canCompute": False, }]
-        update_multiple_acl = self.workspace.update_multiple_users_acl(acl_list=acl_list, invite_users_not_found=False)
+        update_multiple_acl = self.workspace.update_multiple_users_acl(acl_list=acl_list, invite_users_not_found=False).json()
         assert update_multiple_acl
 
     @responses.activate


### PR DESCRIPTION
[POD-2677](https://broadinstitute.atlassian.net/browse/POD-2677): Make Terra API call return types more consistent

Relates to: https://github.com/broadinstitute/ops-terra-utils/pull/264 

[POD-2677]: https://broadinstitute.atlassian.net/browse/POD-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ